### PR TITLE
Response Time Verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.0.21
+
+- Added an option to verify response times
+
 ## v1.0.20
 
 - Update dependencies

--- a/exthttpcheck/check.go
+++ b/exthttpcheck/check.go
@@ -249,13 +249,13 @@ func requestWorker(executionRunData *ExecutionRunData, state *HTTPCheckState, ch
 						}
 					}
 				}
-				if state.ResponseTimeMode == "LESS_THAN" {
+				if state.ResponseTimeMode == "SHORTER_THAN" {
 					if responseTimeValue > float64(state.ResponseTime.Milliseconds()) {
 						responseTimeWasSuccessful = false
 					}
 					metricMap["response_time_constraints_fulfilled"] = strconv.FormatBool(responseTimeWasSuccessful)
 				}
-				if state.ResponseTimeMode == "GREATER_THAN" {
+				if state.ResponseTimeMode == "LONGER_THAN" {
 					if responseTimeValue < float64(state.ResponseTime.Milliseconds()) {
 						responseTimeWasSuccessful = false
 					}

--- a/exthttpcheck/common.go
+++ b/exthttpcheck/common.go
@@ -129,7 +129,7 @@ var (
 	responsesTimeMode = action_kit_api.ActionParameter{
 		Name:         "responseTimeMode",
 		Label:        "Response Time Verification Mode",
-		Description:  extutil.Ptr("Should the Response Time be less or greater than the given value?"),
+		Description:  extutil.Ptr("Should the Response Time be shorter or longer than the given duration?"),
 		Type:         action_kit_api.String,
 		Required:     extutil.Ptr(false),
 		Order:        extutil.Ptr(14),
@@ -140,12 +140,12 @@ var (
 				Value: "NO_VERIFICATION",
 			},
 			action_kit_api.ExplicitParameterOption{
-				Label: "less than",
-				Value: "LESS_THAN",
+				Label: "shorter than",
+				Value: "SHORTER_THAN",
 			},
 			action_kit_api.ExplicitParameterOption{
-				Label: "greater than",
-				Value: "GREATER_THAN",
+				Label: "longer than",
+				Value: "LONGER_THAN",
 			},
 		}),
 	}
@@ -158,6 +158,22 @@ var (
 		Order:        extutil.Ptr(15),
 		DefaultValue: extutil.Ptr("500ms"),
 	}
+	maxConcurrent = action_kit_api.ActionParameter{
+		Name:         "maxConcurrent",
+		Label:        "Max concurrent requests",
+		Description:  extutil.Ptr("Maximum count on parallel running requests. (min 1, max 10)"),
+		Type:         action_kit_api.Integer,
+		DefaultValue: extutil.Ptr("5"),
+		Required:     extutil.Ptr(true),
+		Advanced:     extutil.Ptr(true),
+		Order:        extutil.Ptr(16),
+	}
+	clientSettings = action_kit_api.ActionParameter{
+		Name:  "clientSettings",
+		Label: "HTTP Client Settings",
+		Type:  action_kit_api.Header,
+		Order: extutil.Ptr(17),
+	}
 	followRedirects = action_kit_api.ActionParameter{
 		Name:        "followRedirects",
 		Label:       "Follow Redirects?",
@@ -165,7 +181,7 @@ var (
 		Type:        action_kit_api.Boolean,
 		Required:    extutil.Ptr(true),
 		Advanced:    extutil.Ptr(true),
-		Order:       extutil.Ptr(16),
+		Order:       extutil.Ptr(18),
 	}
 	connectTimeout = action_kit_api.ActionParameter{
 		Name:         "connectTimeout",
@@ -175,7 +191,7 @@ var (
 		DefaultValue: extutil.Ptr("5s"),
 		Required:     extutil.Ptr(true),
 		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(17),
+		Order:        extutil.Ptr(19),
 	}
 	readTimeout = action_kit_api.ActionParameter{
 		Name:         "readTimeout",
@@ -185,16 +201,6 @@ var (
 		DefaultValue: extutil.Ptr("5s"),
 		Required:     extutil.Ptr(true),
 		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(18),
-	}
-	maxConcurrent = action_kit_api.ActionParameter{
-		Name:         "maxConcurrent",
-		Label:        "Max concurrent requests",
-		Description:  extutil.Ptr("Maximum count on parallel running requests. (min 1, max 10)"),
-		Type:         action_kit_api.Integer,
-		DefaultValue: extutil.Ptr("5"),
-		Required:     extutil.Ptr(true),
-		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(19),
+		Order:        extutil.Ptr(20),
 	}
 )

--- a/exthttpcheck/common.go
+++ b/exthttpcheck/common.go
@@ -98,6 +98,17 @@ var (
 		Type:  action_kit_api.Header,
 		Order: extutil.Ptr(10),
 	}
+	successRate = action_kit_api.ActionParameter{
+		Name:         "successRate",
+		Label:        "Required Success Rate",
+		Description:  extutil.Ptr("How many percent of the Request must be at least successful (in terms of the following response verifications) to continue the experiment execution? The result will be evaluated and the end of the given duration."),
+		Type:         action_kit_api.Percentage,
+		DefaultValue: extutil.Ptr("100"),
+		Required:     extutil.Ptr(true),
+		Order:        extutil.Ptr(11),
+		MinValue:     extutil.Ptr(0),
+		MaxValue:     extutil.Ptr(100),
+	}
 	statusCode = action_kit_api.ActionParameter{
 		Name:         "statusCode",
 		Label:        "Response status codes",
@@ -105,18 +116,7 @@ var (
 		Type:         action_kit_api.String,
 		DefaultValue: extutil.Ptr("200-299"),
 		Required:     extutil.Ptr(true),
-		Order:        extutil.Ptr(11),
-	}
-	successRate = action_kit_api.ActionParameter{
-		Name:         "successRate",
-		Label:        "Required Success Rate",
-		Description:  extutil.Ptr("How many percent of the Request must be at least successful (in terms of the given response status codes above) to continue the experiment execution? The result will be evaluated and the end of the given duration."),
-		Type:         action_kit_api.Percentage,
-		DefaultValue: extutil.Ptr("100"),
-		Required:     extutil.Ptr(true),
 		Order:        extutil.Ptr(12),
-		MinValue:     extutil.Ptr(0),
-		MaxValue:     extutil.Ptr(100),
 	}
 	responsesContains = action_kit_api.ActionParameter{
 		Name:        "responsesContains",
@@ -126,6 +126,38 @@ var (
 		Required:    extutil.Ptr(false),
 		Order:       extutil.Ptr(13),
 	}
+	responsesTimeMode = action_kit_api.ActionParameter{
+		Name:         "responseTimeMode",
+		Label:        "Response Time Verification Mode",
+		Description:  extutil.Ptr("Should the Response Time be less or greater than the given value?"),
+		Type:         action_kit_api.String,
+		Required:     extutil.Ptr(false),
+		Order:        extutil.Ptr(14),
+		DefaultValue: extutil.Ptr("NO_VERIFICATION"),
+		Options: extutil.Ptr([]action_kit_api.ParameterOption{
+			action_kit_api.ExplicitParameterOption{
+				Label: "no verification",
+				Value: "NO_VERIFICATION",
+			},
+			action_kit_api.ExplicitParameterOption{
+				Label: "less than",
+				Value: "LESS_THAN",
+			},
+			action_kit_api.ExplicitParameterOption{
+				Label: "greater than",
+				Value: "GREATER_THAN",
+			},
+		}),
+	}
+	responseTime = action_kit_api.ActionParameter{
+		Name:         "responseTime",
+		Label:        "Response Time",
+		Description:  extutil.Ptr("The value for the response time verification."),
+		Type:         action_kit_api.Duration,
+		Required:     extutil.Ptr(false),
+		Order:        extutil.Ptr(15),
+		DefaultValue: extutil.Ptr("500ms"),
+	}
 	followRedirects = action_kit_api.ActionParameter{
 		Name:        "followRedirects",
 		Label:       "Follow Redirects?",
@@ -133,7 +165,7 @@ var (
 		Type:        action_kit_api.Boolean,
 		Required:    extutil.Ptr(true),
 		Advanced:    extutil.Ptr(true),
-		Order:       extutil.Ptr(14),
+		Order:       extutil.Ptr(16),
 	}
 	connectTimeout = action_kit_api.ActionParameter{
 		Name:         "connectTimeout",
@@ -143,7 +175,7 @@ var (
 		DefaultValue: extutil.Ptr("5s"),
 		Required:     extutil.Ptr(true),
 		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(15),
+		Order:        extutil.Ptr(17),
 	}
 	readTimeout = action_kit_api.ActionParameter{
 		Name:         "readTimeout",
@@ -153,7 +185,7 @@ var (
 		DefaultValue: extutil.Ptr("5s"),
 		Required:     extutil.Ptr(true),
 		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(16),
+		Order:        extutil.Ptr(18),
 	}
 	maxConcurrent = action_kit_api.ActionParameter{
 		Name:         "maxConcurrent",
@@ -163,6 +195,6 @@ var (
 		DefaultValue: extutil.Ptr("5"),
 		Required:     extutil.Ptr(true),
 		Advanced:     extutil.Ptr(true),
-		Order:        extutil.Ptr(17),
+		Order:        extutil.Ptr(19),
 	}
 )

--- a/exthttpcheck/fixAmount.go
+++ b/exthttpcheck/fixAmount.go
@@ -101,9 +101,11 @@ func (l *httpCheckActionFixedAmount) Describe() action_kit_api.ActionDescription
 			// Result Verification
 			//------------------------
 			resultVerification,
-			statusCode,
 			successRate,
+			statusCode,
 			responsesContains,
+			responsesTimeMode,
+			responseTime,
 
 			//------------------------
 			// Additional Settings

--- a/exthttpcheck/fixAmount.go
+++ b/exthttpcheck/fixAmount.go
@@ -111,10 +111,11 @@ func (l *httpCheckActionFixedAmount) Describe() action_kit_api.ActionDescription
 			// Additional Settings
 			//------------------------
 
+			maxConcurrent,
+			clientSettings,
 			followRedirects,
 			connectTimeout,
 			readTimeout,
-			maxConcurrent,
 		},
 		Status: extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{
 			CallInterval: extutil.Ptr("1s"),

--- a/exthttpcheck/periodically.go
+++ b/exthttpcheck/periodically.go
@@ -110,10 +110,11 @@ func (l *httpCheckActionPeriodically) Describe() action_kit_api.ActionDescriptio
 			// Additional Settings
 			//------------------------
 
+			maxConcurrent,
+			clientSettings,
 			followRedirects,
 			connectTimeout,
 			readTimeout,
-			maxConcurrent,
 		},
 		Status: extutil.Ptr(action_kit_api.MutatingEndpointReferenceWithCallInterval{
 			CallInterval: extutil.Ptr("1s"),

--- a/exthttpcheck/periodically.go
+++ b/exthttpcheck/periodically.go
@@ -100,9 +100,11 @@ func (l *httpCheckActionPeriodically) Describe() action_kit_api.ActionDescriptio
 			// Result Verification
 			//------------------------
 			resultVerification,
-			statusCode,
 			successRate,
+			statusCode,
 			responsesContains,
+			responsesTimeMode,
+			responseTime,
 
 			//------------------------
 			// Additional Settings


### PR DESCRIPTION
I added an option to configure response time verifications for the HTTP checks.

@ManuelGerding already voted against it because it's too close to the "advanced setting" and the timeouts. But I still like it and let it rest in this PR 😭. In my opinion, the client timeouts are more technical, less obvious, and slightly different.


## Configure request to have a response time less than 400ms
![screenshot- 2024-08-15 um 15 52 46](https://github.com/user-attachments/assets/e8767939-1d6f-455d-905e-2fb554e93624)

## Run View
![screenshot- 2024-08-15 um 15 52 17](https://github.com/user-attachments/assets/0d6fcd94-62ed-4f2a-ae19-d6108cf69cf3)
![screenshot- 2024-08-15 um 15 52 25](https://github.com/user-attachments/assets/617ddd24-2094-4008-950e-172206e4e7d3)

## Verification Options ("no verification" is the default)
![screenshot- 2024-08-15 um 15 53 10](https://github.com/user-attachments/assets/6dbb536b-db95-42cf-b6b1-e5ce41dcae54)

## Client Timeout Settings in the "Advanced" area
![screenshot- 2024-08-15 um 15 52 54](https://github.com/user-attachments/assets/b10c9f3c-3877-44d9-88fa-1ede6a95db00)

## Run View with failing Requests due to a read timeout
![screenshot- 2024-08-15 um 16 07 26](https://github.com/user-attachments/assets/b0bfc424-fd33-41cd-8811-b4cf8e095a6c)

