### PR TITLE
Line Chart Widget

### DIFF
--- a/exthttpcheck/common.go
+++ b/exthttpcheck/common.go
@@ -204,4 +204,76 @@ var (
 		Advanced:     extutil.Ptr(true),
 		Order:        extutil.Ptr(20),
 	}
+	widgets = extutil.Ptr([]action_kit_api.Widget{
+		action_kit_api.LineChartWidget{
+			Type:  action_kit_api.ComSteadybitWidgetLineChart,
+			Title: "HTTP Responses",
+			Identity: action_kit_api.LineChartWidgetIdentityConfig{
+				MetricName: "response_time",
+				From:       "url",
+				Mode:       action_kit_api.ComSteadybitWidgetLineChartIdentityModeWidgetPerValue,
+			},
+			Grouping: extutil.Ptr(action_kit_api.LineChartWidgetGroupingConfig{
+				ShowSummary: extutil.Ptr(true),
+				Groups: []action_kit_api.LineChartWidgetGroup{
+					{
+						Title: "Successul",
+						Color: "success",
+						Matcher: action_kit_api.LineChartWidgetGroupMatcherFallback{
+							Type: action_kit_api.ComSteadybitWidgetLineChartGroupMatcherFallback,
+						},
+					},
+					{
+						Title: "Failure",
+						Color: "danger",
+						Matcher: action_kit_api.LineChartWidgetGroupMatcherNotEmpty{
+							Type: action_kit_api.ComSteadybitWidgetLineChartGroupMatcherNotEmpty,
+							Key:  "error",
+						},
+					},
+					{
+						Title: "Unexpected Status",
+						Color: "warn",
+						Matcher: action_kit_api.LineChartWidgetGroupMatcherKeyEqualsValue{
+							Type:  action_kit_api.ComSteadybitWidgetLineChartGroupMatcherKeyEqualsValue,
+							Key:   "expected_http_status",
+							Value: "false",
+						},
+					},
+					{
+						Title: "Body Constraint Violated",
+						Color: "warn",
+						Matcher: action_kit_api.LineChartWidgetGroupMatcherKeyEqualsValue{
+							Type:  action_kit_api.ComSteadybitWidgetLineChartGroupMatcherKeyEqualsValue,
+							Key:   "response_constraints_fulfilled",
+							Value: "false",
+						},
+					},
+					{
+						Title: "Response Time Constraint Violated",
+						Color: "warn",
+						Matcher: action_kit_api.LineChartWidgetGroupMatcherKeyEqualsValue{
+							Type:  action_kit_api.ComSteadybitWidgetLineChartGroupMatcherKeyEqualsValue,
+							Key:   "response_time_constraints_fulfilled",
+							Value: "false",
+						},
+					},
+				},
+			}),
+			Tooltip: extutil.Ptr(action_kit_api.LineChartWidgetTooltipConfig{
+				MetricValueTitle: extutil.Ptr("Response Time"),
+				MetricValueUnit:  extutil.Ptr("ms"),
+				AdditionalContent: []action_kit_api.LineChartWidgetTooltipContent{
+					{
+						From:  "error",
+						Title: "Error",
+					},
+					{
+						From:  "http_status",
+						Title: "HTTP Status",
+					},
+				},
+			}),
+		},
+	})
 )

--- a/exthttpcheck/fixAmount.go
+++ b/exthttpcheck/fixAmount.go
@@ -41,12 +41,7 @@ func (l *httpCheckActionFixedAmount) Describe() action_kit_api.ActionDescription
 		Description: "Calls an http endpoint a specified number of times and checks the response",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:        extutil.Ptr(targetIconFixedAmount),
-		Widgets: extutil.Ptr([]action_kit_api.Widget{
-			action_kit_api.PredefinedWidget{
-				Type:               action_kit_api.ComSteadybitWidgetPredefined,
-				PredefinedWidgetId: "com.steadybit.widget.predefined.HttpCheck",
-			},
-		}),
+		Widgets:     widgets,
 
 		Technology: extutil.Ptr("HTTP"),
 		Category:   extutil.Ptr("HTTP"), //Can be removed in Q1/24 - support for backward compatibility of old sidebar

--- a/exthttpcheck/periodically.go
+++ b/exthttpcheck/periodically.go
@@ -40,12 +40,7 @@ func (l *httpCheckActionPeriodically) Describe() action_kit_api.ActionDescriptio
 		Description: "Calls a http endpoint periodically (requests / s) and checks the response",
 		Version:     extbuild.GetSemverVersionStringOrUnknown(),
 		Icon:        extutil.Ptr(targetIconPeriodically),
-		Widgets: extutil.Ptr([]action_kit_api.Widget{
-			action_kit_api.PredefinedWidget{
-				Type:               action_kit_api.ComSteadybitWidgetPredefined,
-				PredefinedWidgetId: "com.steadybit.widget.predefined.HttpCheck",
-			},
-		}),
+		Widgets:     widgets,
 
 		Technology: extutil.Ptr("HTTP"),
 		Category:   extutil.Ptr("HTTP"), //Can be removed in Q1/24 - support for backward compatibility of old sidebar

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/rs/zerolog v1.33.0
-	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.3
+	github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.4
 	github.com/steadybit/action-kit/go/action_kit_sdk v1.1.12
 	github.com/steadybit/action-kit/go/action_kit_test v1.3.0
 	github.com/steadybit/extension-kit v1.8.18

--- a/go.sum
+++ b/go.sum
@@ -151,8 +151,8 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spkg/bom v0.0.0-20160624110644-59b7046e48ad/go.mod h1:qLr4V1qq6nMqFKkMo8ZTx3f+BZEkzsRUY10Xsm2mwU0=
-github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.3 h1:NUFdSLNJ0WiO8azy0KdiFZgSARzaNL0g4ek6cN2lATs=
-github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.3/go.mod h1:ycF2RLgRsB8I/jD52aE+dKZKVru1GIEtmkcRcIR3vXk=
+github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.4 h1:imlfn0m5FEwZ3/ad75TgI5DoGQD4ztnSoLfPR4afqUY=
+github.com/steadybit/action-kit/go/action_kit_api/v2 v2.9.4/go.mod h1:ycF2RLgRsB8I/jD52aE+dKZKVru1GIEtmkcRcIR3vXk=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.12 h1:qHgEHBbp83QxVoS9UuBc9EDbBkAyF8UWhDG0/VwoYYQ=
 github.com/steadybit/action-kit/go/action_kit_sdk v1.1.12/go.mod h1:D8eHLbT+C797myIwacybsz0bqDfS1ShpIzjr+eSweX0=
 github.com/steadybit/action-kit/go/action_kit_test v1.3.0 h1:PZ8BfKQyFlFmbOcrp0PKHjHFT3S8y3mOBTGo/mGQcAE=


### PR DESCRIPTION
This PR replaces the usage of the predefined HTTP Widget with the generic Line-Chart-Widget.

We should merge that when we are sure all customers are using the required agent and platform (Q1/25)