### PR TITLE
fix: ignore inflight requests

### DIFF
--- a/exthttpcheck/check.go
+++ b/exthttpcheck/check.go
@@ -10,30 +10,13 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/steadybit/action-kit/go/action_kit_api/v2"
 	"github.com/steadybit/extension-kit/extutil"
-	"golang.org/x/exp/slices"
-	"io"
-	"net"
-	"net/http"
-	"net/http/httptrace"
 	"net/url"
-	"strconv"
-	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 )
 
-type ExecutionRunData struct {
-	stopTicker            chan bool                  // stores the stop channels for each execution
-	jobs                  chan time.Time             // stores the jobs for each execution
-	tickers               *time.Ticker               // stores the tickers for each execution, to be able to stop them
-	metrics               chan action_kit_api.Metric // stores the metrics for each execution
-	requestCounter        atomic.Uint64              // stores the number of requests for each execution
-	requestSuccessCounter atomic.Uint64              // stores the number of successful requests for each execution
-}
-
 var (
-	ExecutionRunDataMap = sync.Map{} //make(map[uuid.UUID]*ExecutionRunData)
+	httpCheckers = sync.Map{} //make(map[uuid.UUID]*httpChecker)
 )
 
 type HTTPCheckState struct {
@@ -57,7 +40,7 @@ type HTTPCheckState struct {
 	FollowRedirects          bool
 }
 
-func prepare(request action_kit_api.PrepareActionRequestBody, state *HTTPCheckState, checkEnded func(executionRunData *ExecutionRunData, state *HTTPCheckState) bool) (*action_kit_api.PrepareResult, error) {
+func prepare(request action_kit_api.PrepareActionRequestBody, state *HTTPCheckState, checkEnded checkEndedFn) (*action_kit_api.PrepareResult, error) {
 	duration := extutil.ToInt64(request.Config["duration"])
 	state.Timeout = time.Now().Add(time.Millisecond * time.Duration(duration))
 	expectedStatusCodes, statusCodeErr := resolveStatusCodeExpression(extutil.ToString(request.Config["statusCode"]))
@@ -97,231 +80,28 @@ func prepare(request action_kit_api.PrepareActionRequestBody, state *HTTPCheckSt
 	}
 	state.URL = *parsedUrl
 
-	initExecutionRunData(state)
-	executionRunData, err := loadExecutionRunData(state.ExecutionID)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to load execution run data")
-		return nil, err
-	}
+	checker := newHttpChecker(state, checkEnded)
+	httpCheckers.Store(state.ExecutionID, checker)
 
-	// create worker pool, and close metrics once all workers are done
-	go func() {
-		var wg sync.WaitGroup
-		for w := 1; w <= state.MaxConcurrent; w++ {
-			wg.Add(1)
-			go requestWorker(executionRunData, state, checkEnded, &wg)
-		}
-		wg.Wait()
-		close(executionRunData.metrics)
-	}()
 	return nil, nil
 }
 
-func loadExecutionRunData(executionID uuid.UUID) (*ExecutionRunData, error) {
-	erd, ok := ExecutionRunDataMap.Load(executionID)
+func loadHttpChecker(executionID uuid.UUID) (*httpChecker, error) {
+	erd, ok := httpCheckers.Load(executionID)
 	if !ok {
-		return nil, fmt.Errorf("failed to load execution run data")
+		return nil, fmt.Errorf("failed to load associated http checker")
 	}
-	executionRunData := erd.(*ExecutionRunData)
-	return executionRunData, nil
-}
-
-func initExecutionRunData(state *HTTPCheckState) {
-	ExecutionRunDataMap.Store(state.ExecutionID, &ExecutionRunData{
-		stopTicker:            make(chan bool),
-		jobs:                  make(chan time.Time, state.MaxConcurrent),
-		metrics:               make(chan action_kit_api.Metric, state.RequestsPerSecond),
-		requestCounter:        atomic.Uint64{},
-		requestSuccessCounter: atomic.Uint64{},
-	})
-}
-
-func createRequest(state *HTTPCheckState) (*http.Request, error) {
-	var body io.Reader = nil
-	if state.Body != "" {
-		body = strings.NewReader(state.Body)
-	}
-	var method = "GET"
-	if state.Method != "" {
-		method = state.Method
-	}
-
-	request, err := http.NewRequest(strings.ToUpper(method), state.URL.String(), body)
-	if err == nil {
-		for k, v := range state.Headers {
-			request.Header.Add(k, v)
-		}
-	}
-	return request, err
-}
-
-func requestWorker(executionRunData *ExecutionRunData, state *HTTPCheckState, checkEnded func(executionRunData *ExecutionRunData, state *HTTPCheckState) bool, wg *sync.WaitGroup) {
-	// restrict idle connections, as all will point to one target
-	transport := &http.Transport{
-		MaxIdleConns:        1,
-		MaxIdleConnsPerHost: 1,
-		DisableKeepAlives:   true,
-		DialContext: (&net.Dialer{
-			Timeout: state.ConnectionTimeout,
-		}).DialContext,
-	}
-	client := http.Client{Timeout: state.ReadTimeout, Transport: transport}
-
-	if !state.FollowRedirects {
-		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-
-	for range executionRunData.jobs {
-		if !checkEnded(executionRunData, state) {
-			var started = time.Now()
-			var requestWritten time.Time
-			var ended time.Time
-
-			// see seems to break a configured proxy. maybe we can use it in the future and configure the proxy here
-			trace := &httptrace.ClientTrace{
-				WroteRequest: func(info httptrace.WroteRequestInfo) {
-					requestWritten = time.Now()
-				},
-				GotFirstResponseByte: func() {
-					ended = time.Now()
-				},
-			}
-
-			responseStatusWasExpected := false
-
-			req, err := createRequest(state)
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to create request")
-				now := time.Now()
-				executionRunData.metrics <- action_kit_api.Metric{
-					Metric: map[string]string{
-						"url":   req.URL.String(),
-						"error": err.Error(),
-					},
-					Name:      extutil.Ptr("response_time"),
-					Value:     float64(now.Sub(started).Milliseconds()),
-					Timestamp: now,
-				}
-				return
-			}
-
-			req = req.WithContext(httptrace.WithClientTrace(req.Context(), trace))
-			log.Debug().Msgf("Requesting %s", req.URL.String())
-			response, err := client.Do(req)
-
-			executionRunData.requestCounter.Add(1)
-
-			if err != nil {
-				log.Error().Err(err).Msg("Failed to execute request")
-				now := time.Now()
-				responseStatusWasExpected = slices.Contains(state.ExpectedStatusCodes, "error")
-				executionRunData.metrics <- action_kit_api.Metric{
-					Metric: map[string]string{
-						"url":                  req.URL.String(),
-						"error":                err.Error(),
-						"expected_http_status": strconv.FormatBool(responseStatusWasExpected),
-					},
-					Name:      extutil.Ptr("response_time"),
-					Value:     float64(now.Sub(started).Milliseconds()),
-					Timestamp: now,
-				}
-				if responseStatusWasExpected {
-					executionRunData.requestSuccessCounter.Add(1)
-				}
-			} else {
-				responseBodyWasSuccessful := true
-				responseTimeWasSuccessful := true
-				responseTimeValue := float64(ended.Sub(requestWritten).Milliseconds())
-				log.Debug().Msgf("Got response %s", response.Status)
-				responseStatusWasExpected = slices.Contains(state.ExpectedStatusCodes, strconv.Itoa(response.StatusCode))
-				metricMap := map[string]string{
-					"url":                  req.URL.String(),
-					"http_status":          strconv.Itoa(response.StatusCode),
-					"expected_http_status": strconv.FormatBool(responseStatusWasExpected),
-				}
-				if state.ResponsesContains != "" {
-					if response.Body == nil {
-						metricMap["response_constraints_fulfilled"] = strconv.FormatBool(false)
-						responseBodyWasSuccessful = false
-					} else {
-						bodyBytes, err := io.ReadAll(response.Body)
-						if err != nil {
-							log.Error().Err(err).Msg("Failed to read response body")
-							metricMap["response_constraints_fulfilled"] = strconv.FormatBool(false)
-							responseBodyWasSuccessful = false
-						} else {
-							bodyString := string(bodyBytes)
-							responseConstraintFulfilled := strings.Contains(bodyString, state.ResponsesContains)
-							metricMap["response_constraints_fulfilled"] = strconv.FormatBool(responseConstraintFulfilled)
-							responseBodyWasSuccessful = responseConstraintFulfilled
-						}
-					}
-				}
-				if state.ResponseTimeMode == "SHORTER_THAN" {
-					if responseTimeValue > float64(state.ResponseTime.Milliseconds()) {
-						responseTimeWasSuccessful = false
-					}
-					metricMap["response_time_constraints_fulfilled"] = strconv.FormatBool(responseTimeWasSuccessful)
-				}
-				if state.ResponseTimeMode == "LONGER_THAN" {
-					if responseTimeValue < float64(state.ResponseTime.Milliseconds()) {
-						responseTimeWasSuccessful = false
-					}
-					metricMap["response_time_constraints_fulfilled"] = strconv.FormatBool(responseTimeWasSuccessful)
-				}
-
-				if responseStatusWasExpected && responseBodyWasSuccessful && responseTimeWasSuccessful {
-					executionRunData.requestSuccessCounter.Add(1)
-				}
-
-				metric := action_kit_api.Metric{
-					Name:      extutil.Ptr("response_time"),
-					Metric:    metricMap,
-					Value:     responseTimeValue,
-					Timestamp: ended,
-				}
-				executionRunData.metrics <- metric
-			}
-			if response != nil && response.Body != nil {
-				_ = response.Body.Close()
-			}
-		}
-	}
-	wg.Done()
+	checker := erd.(*httpChecker)
+	return checker, nil
 }
 
 func start(state *HTTPCheckState) {
-	executionRunData, err := loadExecutionRunData(state.ExecutionID)
+	checker, err := loadHttpChecker(state.ExecutionID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to load execution run data")
 	}
-	executionRunData.tickers = time.NewTicker(time.Duration(state.DelayBetweenRequestsInMS) * time.Millisecond)
 
-	now := time.Now()
-	log.Debug().Msgf("Schedule first Request at %v", now)
-	executionRunData.jobs <- now
-	go func() {
-		for {
-			select {
-			case _, ok := <-executionRunData.stopTicker:
-				if !ok {
-					log.Debug().Msg("Stop Request Scheduler")
-					// close jobs channel to free worker goroutines
-					close(executionRunData.jobs)
-					executionRunData.tickers.Stop()
-					ExecutionRunDataMap.Delete(state.ExecutionID)
-					log.Trace().Msg("Stopped Request Scheduler")
-					return
-				}
-			case t := <-executionRunData.tickers.C:
-				log.Debug().Msgf("Schedule Request at %v", t)
-				executionRunData.jobs <- t
-			}
-		}
-	}()
-	ExecutionRunDataMap.Store(state.ExecutionID, executionRunData)
+	checker.start()
 }
 
 func retrieveLatestMetrics(metrics chan action_kit_api.Metric) []action_kit_api.Metric {
@@ -344,33 +124,34 @@ func retrieveLatestMetrics(metrics chan action_kit_api.Metric) []action_kit_api.
 }
 
 func stop(state *HTTPCheckState) (*action_kit_api.StopResult, error) {
-	executionRunData, err := loadExecutionRunData(state.ExecutionID)
+	checker, err := loadHttpChecker(state.ExecutionID)
 	if err != nil {
 		log.Debug().Err(err).Msg("Execution run data not found, stop was already called")
 		return nil, nil
 	}
 
-	// Close ticker to stop sending requests
-	if executionRunData.stopTicker != nil {
-		close(executionRunData.stopTicker)
-	}
+	checker.stop()
+	httpCheckers.Delete(state.ExecutionID)
 
-	latestMetrics := retrieveLatestMetrics(executionRunData.metrics)
-	// calculate the success rate
-	successRate := float64(executionRunData.requestSuccessCounter.Load()) / float64(executionRunData.requestCounter.Load()) * 100
-	log.Debug().Msgf("Success Rate: %v%%", successRate)
+	latestMetrics := retrieveLatestMetrics(checker.metrics)
+	success := checker.counterReqSuccess.Load()
+	failed := checker.counterReqFailed.Load()
+	total := success + failed
+
+	successRate := float64(success) / float64(total) * 100.0
+
+	log.Debug().Msgf("Success Rate: %.2f%% (%d of %d)", successRate, success, total)
 	if successRate < float64(state.SuccessRate) {
 		log.Info().Msgf("Success Rate (%.2f%%) was below %v%%", successRate, state.SuccessRate)
-		return extutil.Ptr(action_kit_api.StopResult{
-			Metrics: extutil.Ptr(latestMetrics),
+		return &action_kit_api.StopResult{
+			Metrics: &latestMetrics,
 			Error: &action_kit_api.ActionKitError{
 				Title:  fmt.Sprintf("Success Rate (%.2f%%) was below %v%%", successRate, state.SuccessRate),
 				Status: extutil.Ptr(action_kit_api.Failed),
 			},
-		}), nil
+		}, nil
 	}
+
 	log.Info().Msgf("Success Rate (%.2f%%) was above/equal %v%%", successRate, state.SuccessRate)
-	return extutil.Ptr(action_kit_api.StopResult{
-		Metrics: extutil.Ptr(latestMetrics),
-	}), nil
+	return &action_kit_api.StopResult{Metrics: &latestMetrics}, nil
 }

--- a/exthttpcheck/httpchecker.go
+++ b/exthttpcheck/httpchecker.go
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package exthttpcheck
+
+import (
+	"github.com/rs/zerolog/log"
+	"github.com/steadybit/action-kit/go/action_kit_api/v2"
+	"github.com/steadybit/extension-kit/extutil"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type checkEndedFn func(checker *httpChecker) bool
+
+type httpChecker struct {
+	work              chan struct{}              // stores the work for each execution
+	ticker            *time.Ticker               // stores the ticker for each execution, to be able to stop them
+	metrics           chan action_kit_api.Metric // stores the metrics for each execution
+	counterReqStarted atomic.Uint64              // stores the number of requests for each execution
+	counterReqSuccess atomic.Uint64              // stores the number of successful requests for each execution
+	counterReqFailed  atomic.Uint64              // stores the number of failed requests for each execution
+	shouldEnd         func() bool                //
+	tickerDelay       time.Duration
+}
+
+func newHttpChecker(state *HTTPCheckState, checkEnded checkEndedFn) *httpChecker {
+	checker := &httpChecker{
+		work:              make(chan struct{}, state.MaxConcurrent),
+		metrics:           make(chan action_kit_api.Metric, state.RequestsPerSecond*2),
+		counterReqStarted: atomic.Uint64{},
+		counterReqSuccess: atomic.Uint64{},
+		tickerDelay:       time.Duration(state.DelayBetweenRequestsInMS) * time.Millisecond,
+	}
+	if checkEnded != nil {
+		checker.shouldEnd = func() bool {
+			return checkEnded(checker)
+		}
+	}
+
+	//start workers doing the actual requests
+	go func() {
+		defer func() {
+			close(checker.metrics)
+		}()
+
+		var wg sync.WaitGroup
+		for w := 1; w <= state.MaxConcurrent; w++ {
+			wg.Add(1)
+			go func() {
+				checker.performRequests(state)
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+	}()
+
+	return checker
+}
+
+func (c *httpChecker) start() {
+	c.ticker = time.NewTicker(c.tickerDelay)
+
+	log.Debug().Msgf("Schedule first Request at %v", time.Now())
+	c.work <- struct{}{}
+
+	go func() {
+		defer func() {
+			close(c.work)
+			log.Trace().Msg("Stopped Request Scheduler")
+		}()
+
+		for t := range c.ticker.C {
+			log.Debug().Msgf("Schedule Request at %v", t)
+			c.work <- struct{}{}
+		}
+	}()
+}
+
+func (c *httpChecker) performRequests(state *HTTPCheckState) {
+	// restrict idle connections, as all will point to one target
+	transport := &http.Transport{
+		MaxIdleConns:        1,
+		MaxIdleConnsPerHost: 1,
+		DisableKeepAlives:   true,
+		DialContext:         (&net.Dialer{Timeout: state.ConnectionTimeout}).DialContext,
+	}
+	client := http.Client{Timeout: state.ReadTimeout, Transport: transport}
+
+	if !state.FollowRedirects {
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+	}
+
+	for range c.work {
+		if c.shouldEnd != nil && c.shouldEnd() {
+			break
+		}
+
+		req, err := createRequest(state)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to create request")
+			c.onError(req, err, 0, false)
+			return
+		}
+
+		tracer := newRequestTracer()
+		req = req.WithContext(httptrace.WithClientTrace(req.Context(), &tracer.ClientTrace))
+
+		log.Debug().Msgf("Requesting %s", req.URL.String())
+		started := time.Now()
+		c.counterReqStarted.Add(1)
+
+		response, err := client.Do(req)
+		if err != nil {
+			log.Error().Err(err).Msg("Failed to execute request")
+			now := time.Now()
+
+			responseStatusWasExpected := slices.Contains(state.ExpectedStatusCodes, "error")
+			c.onError(req, err, now.Sub(started).Milliseconds(), responseStatusWasExpected)
+		} else {
+			log.Debug().Msgf("Got response %s", response.Status)
+
+			responseStatusWasExpected := slices.Contains(state.ExpectedStatusCodes, strconv.Itoa(response.StatusCode))
+
+			responseBodyWasSuccessful := true
+			if state.ResponsesContains != "" {
+				if response.Body == nil {
+					responseBodyWasSuccessful = false
+				} else {
+					if bodyBytes, err := io.ReadAll(response.Body); err != nil {
+						log.Error().Err(err).Msg("Failed to read response body")
+						responseBodyWasSuccessful = false
+					} else {
+						bodyString := string(bodyBytes)
+						responseBodyWasSuccessful = strings.Contains(bodyString, state.ResponsesContains)
+					}
+				}
+			}
+
+			var responseTimeWasSuccessful bool
+			switch state.ResponseTimeMode {
+			case "SHORTER_THAN":
+				responseTimeWasSuccessful = tracer.responseTime() <= *state.ResponseTime
+			case "LONGER_THAN":
+				responseTimeWasSuccessful = tracer.responseTime() >= *state.ResponseTime
+			default:
+				responseTimeWasSuccessful = true
+			}
+
+			c.onResponse(req, response, tracer, responseStatusWasExpected, responseBodyWasSuccessful, responseTimeWasSuccessful)
+
+			if response.Body != nil {
+				_ = response.Body.Close()
+			}
+		}
+	}
+}
+
+func (c *httpChecker) onError(req *http.Request, err error, value int64, responseStatusWasExpected bool) {
+	metric := action_kit_api.Metric{
+		Metric: map[string]string{
+			"url":                  req.URL.String(),
+			"error":                err.Error(),
+			"expected_http_status": strconv.FormatBool(responseStatusWasExpected),
+		},
+		Name:      extutil.Ptr("response_time"),
+		Value:     float64(value),
+		Timestamp: time.Now(),
+	}
+
+	if responseStatusWasExpected {
+		c.counterReqSuccess.Add(1)
+	} else {
+		c.counterReqFailed.Add(1)
+	}
+	c.metrics <- metric
+}
+
+func (c *httpChecker) onResponse(req *http.Request, res *http.Response, tracer *requestTracer, responseStatusWasExpected bool, responseBodyWasSuccessful bool, responseTimeWasSuccessful bool) {
+	metric := action_kit_api.Metric{
+		Name: extutil.Ptr("response_time"),
+		Metric: map[string]string{
+			"url":                                 req.URL.String(),
+			"http_status":                         strconv.Itoa(res.StatusCode),
+			"expected_http_status":                strconv.FormatBool(responseStatusWasExpected),
+			"response_constraints_fulfilled":      strconv.FormatBool(responseBodyWasSuccessful),
+			"response_time_constraints_fulfilled": strconv.FormatBool(responseTimeWasSuccessful),
+		},
+		Value:     float64(tracer.responseTime().Milliseconds()),
+		Timestamp: tracer.firstByteReceived,
+	}
+
+	if responseStatusWasExpected && responseBodyWasSuccessful && responseTimeWasSuccessful {
+		c.counterReqSuccess.Add(1)
+	} else {
+		c.counterReqFailed.Add(1)
+	}
+
+	c.metrics <- metric
+}
+
+func (c *httpChecker) stop() {
+	if c.ticker != nil {
+		c.ticker.Stop()
+	}
+}
+
+func createRequest(state *HTTPCheckState) (*http.Request, error) {
+	var body io.Reader
+	if state.Body != "" {
+		body = strings.NewReader(state.Body)
+	}
+	var method = "GET"
+	if state.Method != "" {
+		method = state.Method
+	}
+
+	request, err := http.NewRequest(strings.ToUpper(method), state.URL.String(), body)
+	if err == nil {
+		for k, v := range state.Headers {
+			request.Header.Add(k, v)
+		}
+	}
+	return request, err
+}

--- a/exthttpcheck/periodically.go
+++ b/exthttpcheck/periodically.go
@@ -141,7 +141,7 @@ func getDelayBetweenRequestsInMsPeriodically(requestsPerSecond uint64) uint64 {
 func (l *httpCheckActionPeriodically) Prepare(_ context.Context, state *HTTPCheckState, request action_kit_api.PrepareActionRequestBody) (*action_kit_api.PrepareResult, error) {
 	state.RequestsPerSecond = extutil.ToUInt64(request.Config["requestsPerSecond"])
 	state.DelayBetweenRequestsInMS = getDelayBetweenRequestsInMsPeriodically(state.RequestsPerSecond)
-	return prepare(request, state, func(executionRunData *ExecutionRunData, state *HTTPCheckState) bool { return false })
+	return prepare(request, state, nil)
 }
 
 // Start is called to start the action
@@ -154,7 +154,7 @@ func (l *httpCheckActionPeriodically) Start(_ context.Context, state *HTTPCheckS
 
 // Status is called to get the current status of the action
 func (l *httpCheckActionPeriodically) Status(_ context.Context, state *HTTPCheckState) (*action_kit_api.StatusResult, error) {
-	executionRunData, err := loadExecutionRunData(state.ExecutionID)
+	executionRunData, err := loadHttpChecker(state.ExecutionID)
 	if err != nil {
 		log.Error().Err(err).Msg("Failed to load execution run data")
 		return nil, err
@@ -170,6 +170,6 @@ func (l *httpCheckActionPeriodically) Stop(_ context.Context, state *HTTPCheckSt
 	return stop(state)
 }
 
-func (l *httpCheckActionPeriodically) getExecutionRunData(executionID uuid.UUID) (*ExecutionRunData, error) {
-	return loadExecutionRunData(executionID)
+func (l *httpCheckActionPeriodically) getExecutionRunData(executionID uuid.UUID) (*httpChecker, error) {
+	return loadHttpChecker(executionID)
 }

--- a/exthttpcheck/periodically_test.go
+++ b/exthttpcheck/periodically_test.go
@@ -122,8 +122,7 @@ func TestNewHTTPCheckActionPeriodically_Prepare(t *testing.T) {
 func TestNewHTTPCheckActionPeriodically_All_Success(t *testing.T) {
 	// generate a test server so we can capture and inspect the request
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.Write([]byte("this is a test response"))
-		res.WriteHeader(200)
+		_, _ = res.Write([]byte("this is a test response"))
 	}))
 	defer func() { testServer.Close() }()
 
@@ -176,14 +175,14 @@ func TestNewHTTPCheckActionPeriodically_All_Success(t *testing.T) {
 
 	executionRunData, err := action.getExecutionRunData(state.ExecutionID)
 	assert.NoError(t, err)
-	assert.Greater(t, executionRunData.requestCounter.Load(), uint64(0))
+	assert.Greater(t, executionRunData.counterReqStarted.Load(), uint64(0))
 
 	// Stop
 	stopResult, err := action.Stop(context.Background(), &state)
 	assert.NoError(t, err)
 	assert.NotNil(t, stopResult.Metrics)
 	assert.Nil(t, stopResult.Error)
-	assert.Greater(t, executionRunData.requestSuccessCounter.Load(), uint64(0))
+	assert.Greater(t, executionRunData.counterReqSuccess.Load(), uint64(0))
 }
 
 func TestNewHTTPCheckActionPeriodically_All_Failure(t *testing.T) {
@@ -241,7 +240,7 @@ func TestNewHTTPCheckActionPeriodically_All_Failure(t *testing.T) {
 
 	executionRunData, err := action.getExecutionRunData(state.ExecutionID)
 	assert.NoError(t, err)
-	assert.Greater(t, executionRunData.requestCounter.Load(), uint64(0))
+	assert.Greater(t, executionRunData.counterReqStarted.Load(), uint64(0))
 
 	// Stop
 	stopResult, err := action.Stop(context.Background(), &state)
@@ -249,5 +248,5 @@ func TestNewHTTPCheckActionPeriodically_All_Failure(t *testing.T) {
 	assert.NotNil(t, stopResult.Metrics)
 	assert.NotNil(t, stopResult.Error)
 	assert.Equal(t, stopResult.Error.Title, "Success Rate (0.00%) was below 100%")
-	assert.Equal(t, executionRunData.requestSuccessCounter.Load(), uint64(0))
+	assert.Equal(t, executionRunData.counterReqSuccess.Load(), uint64(0))
 }

--- a/exthttpcheck/requestTracer.go
+++ b/exthttpcheck/requestTracer.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Steadybit GmbH
+
+package exthttpcheck
+
+import (
+	"net/http/httptrace"
+	"time"
+)
+
+type requestTracer struct {
+	httptrace.ClientTrace
+	requestWritten, firstByteReceived time.Time
+}
+
+func (t requestTracer) responseTime() time.Duration {
+	return t.firstByteReceived.Sub(t.requestWritten)
+}
+
+func newRequestTracer() *requestTracer {
+	t := &requestTracer{}
+
+	// see seems to break a configured proxy. maybe we can use it in the future and configure the proxy here
+	t.ClientTrace = httptrace.ClientTrace{
+		WroteRequest: func(info httptrace.WroteRequestInfo) {
+			t.requestWritten = time.Now()
+		},
+		GotFirstResponseByte: func() {
+			t.firstByteReceived = time.Now()
+		},
+	}
+
+	return t
+}

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,6 @@ require (
 	github.com/steadybit/extension-kit v1.9.0
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/automaxprocs v1.6.0
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -172,8 +172,6 @@ go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwE
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c h1:7dEasQXItcW1xKJ2+gg5VOiBnqWrJc+rq0DPKyvvdbY=
-golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c/go.mod h1:NQtJDoLvd6faHhE7m4T/1IY708gDefGGjR/iUW8yQQ8=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/main.go
+++ b/main.go
@@ -20,7 +20,6 @@ import (
 	"github.com/steadybit/extension-kit/extruntime"
 	"github.com/steadybit/extension-kit/extsignals"
 	_ "go.uber.org/automaxprocs" // Importing automaxprocs automatically adjusts GOMAXPROCS.
-	_ "net/http/pprof"           //allow pprof
 )
 
 func main() {


### PR DESCRIPTION
When ending the http check and calculating request success rate, we need to ignore all unfinished requests.