### PR TITLE
fix: bandwidth check fails despite healthy throughput

### DIFF
--- a/exthttpcheck/bandwidth.go
+++ b/exthttpcheck/bandwidth.go
@@ -23,6 +23,14 @@ const (
 	actionIconBandwidth = "data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%2224%22%20height%3D%2224%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke%3D%22%231D2632%22%20stroke-width%3D%221.6%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Cpath%20d%3D%22M22%2012h-4l-3%209L9%203l-3%209H2%22%2F%3E%3C%2Fsvg%3E"
 )
 
+// bandwidthSuccessRate reuses the shared success-rate parameter but describes it
+// in terms of measurement windows, which is how the bandwidth check evaluates it.
+var bandwidthSuccessRate = func() action_kit_api.ActionParameter {
+	p := successRate
+	p.Description = new("Percentage of measurement windows that must be within the bandwidth thresholds. Evaluated at the end of the duration.")
+	return p
+}()
+
 type httpCheckActionBandwidth struct{}
 
 type BandwidthCheckState struct {
@@ -85,20 +93,20 @@ func (a *httpCheckActionBandwidth) Describe() action_kit_api.ActionDescription {
 							},
 						},
 						{
+							Title: "Error",
+							Color: "warn",
+							Matcher: action_kit_api.LineChartWidgetGroupMatcherNotEmpty{
+								Type: action_kit_api.ComSteadybitWidgetLineChartGroupMatcherNotEmpty,
+								Key:  "error",
+							},
+						},
+						{
 							Title: "Outside Threshold",
 							Color: "warn",
 							Matcher: action_kit_api.LineChartWidgetGroupMatcherKeyEqualsValue{
 								Type:  action_kit_api.ComSteadybitWidgetLineChartGroupMatcherKeyEqualsValue,
 								Key:   "within_threshold",
 								Value: "false",
-							},
-						},
-						{
-							Title: "Error",
-							Color: "warn",
-							Matcher: action_kit_api.LineChartWidgetGroupMatcherNotEmpty{
-								Type: action_kit_api.ComSteadybitWidgetLineChartGroupMatcherNotEmpty,
-								Key:  "error",
 							},
 						},
 					},
@@ -170,7 +178,7 @@ func (a *httpCheckActionBandwidth) Describe() action_kit_api.ActionDescription {
 				Type:  action_kit_api.ActionParameterTypeHeader,
 				Order: new(10),
 			},
-			successRate,
+			bandwidthSuccessRate,
 			{
 				Name:        "minBandwidth",
 				Label:       "Minimum Bandwidth",
@@ -352,6 +360,20 @@ func (a *httpCheckActionBandwidth) Stop(_ context.Context, state *BandwidthCheck
 		return &action_kit_api.StopResult{
 			Error: &action_kit_api.ActionKitError{
 				Title:  "No measurement windows were completed",
+				Status: extutil.Ptr(action_kit_api.Failed),
+			},
+		}, nil
+	}
+
+	// Guard against a target that delivers throughput but fails every request
+	// (e.g. resets mid-body): such a run could otherwise pass on bandwidth alone.
+	// Requiring an actual error avoids penalising a long download that is still in
+	// flight at stop, where no request has completed yet but none has failed either.
+	if checker.counterRequestsCompleted.Load() == 0 && checker.counterRequestsErrored.Load() > 0 {
+		return &action_kit_api.StopResult{
+			Metrics: &latestMetrics,
+			Error: &action_kit_api.ActionKitError{
+				Title:  "No HTTP requests completed successfully during the bandwidth check (the target is unreachable or failing all requests)",
 				Status: extutil.Ptr(action_kit_api.Failed),
 			},
 		}, nil

--- a/exthttpcheck/bandwidthChecker.go
+++ b/exthttpcheck/bandwidthChecker.go
@@ -33,6 +33,12 @@ type bandwidthChecker struct {
 	counterWindowSuccess atomic.Uint64
 	counterWindowFailed  atomic.Uint64
 
+	// Total requests that completed successfully and that errored across the whole
+	// run, used to detect a target that is failing every request regardless of
+	// throughput, without penalising long downloads still in flight at stop.
+	counterRequestsCompleted atomic.Uint64
+	counterRequestsErrored   atomic.Uint64
+
 	// Control
 	stopped atomic.Bool
 	state   *BandwidthCheckState
@@ -160,6 +166,8 @@ func (c *bandwidthChecker) recordBytes(bytesDownloaded int64) {
 }
 
 func (c *bandwidthChecker) recordRequestCompleted() {
+	c.counterRequestsCompleted.Add(1)
+
 	c.windowMu.Lock()
 	defer c.windowMu.Unlock()
 
@@ -167,6 +175,8 @@ func (c *bandwidthChecker) recordRequestCompleted() {
 }
 
 func (c *bandwidthChecker) recordError() {
+	c.counterRequestsErrored.Add(1)
+
 	c.windowMu.Lock()
 	defer c.windowMu.Unlock()
 
@@ -207,7 +217,11 @@ func (c *bandwidthChecker) emitWindowMetric() *action_kit_api.Metric {
 	bandwidthBps := float64(bytesDownloaded*8) / windowSeconds
 	bandwidthMbps := bandwidthBps / 1_000_000
 
-	// Check thresholds
+	// A window is within threshold when the bandwidth it actually achieved falls
+	// within the configured limits. Failed requests do not by themselves fail a
+	// window as long as data was received, because long downloads frequently span
+	// multiple windows and complete in bursts: a window can legitimately receive
+	// megabytes of in-flight data while no request happens to finish within it.
 	withinThreshold := true
 	if c.state.MinBandwidthBps > 0 && bandwidthBps < float64(c.state.MinBandwidthBps) {
 		withinThreshold = false
@@ -218,8 +232,11 @@ func (c *bandwidthChecker) emitWindowMetric() *action_kit_api.Metric {
 		log.Trace().Msgf("Window bandwidth %.2f bps is above maximum %d bps", bandwidthBps, c.state.MaxBandwidthBps)
 	}
 
-	// Consider window failed if there were errors and no successful requests
-	if errorCount > 0 && requestCount == 0 {
+	// Only treat errors as a window failure when no data was received at all,
+	// i.e. a genuine stall or outage. This still fails maximum-only configurations,
+	// where a zero-bandwidth window would otherwise pass the maximum check.
+	failedWithoutData := errorCount > 0 && bytesDownloaded == 0
+	if failedWithoutData {
 		withinThreshold = false
 	}
 
@@ -230,17 +247,22 @@ func (c *bandwidthChecker) emitWindowMetric() *action_kit_api.Metric {
 		c.counterWindowFailed.Add(1)
 	}
 
+	metricLabels := map[string]string{
+		"url":              c.state.URL.String(),
+		"bytes_downloaded": strconv.FormatInt(bytesDownloaded, 10),
+		"duration_ms":      strconv.FormatInt(windowDuration.Milliseconds(), 10),
+		"request_count":    strconv.FormatInt(requestCount, 10),
+		"error_count":      strconv.FormatInt(errorCount, 10),
+		"within_threshold": strconv.FormatBool(withinThreshold),
+		"bandwidth":        strconv.FormatFloat(bandwidthMbps, 'g', -1, 64),
+	}
+	if failedWithoutData {
+		metricLabels["error"] = fmt.Sprintf("%d request(s) failed without receiving any data", errorCount)
+	}
+
 	metric := &action_kit_api.Metric{
-		Name: new("bandwidth"),
-		Metric: map[string]string{
-			"url":              c.state.URL.String(),
-			"bytes_downloaded": strconv.FormatInt(bytesDownloaded, 10),
-			"duration_ms":      strconv.FormatInt(windowDuration.Milliseconds(), 10),
-			"request_count":    strconv.FormatInt(requestCount, 10),
-			"error_count":      strconv.FormatInt(errorCount, 10),
-			"within_threshold": strconv.FormatBool(withinThreshold),
-			"bandwidth":        strconv.FormatFloat(bandwidthMbps, 'g', -1, 64),
-		},
+		Name:      new("bandwidth"),
+		Metric:    metricLabels,
 		Value:     math.Trunc(bandwidthMbps*100) / 100,
 		Timestamp: time.Now(),
 	}

--- a/exthttpcheck/bandwidth_test.go
+++ b/exthttpcheck/bandwidth_test.go
@@ -323,6 +323,110 @@ func TestBandwidthCheckAction_BigFileDownload(t *testing.T) {
 	}
 }
 
+func TestBandwidthChecker_WindowClassification(t *testing.T) {
+	// All cases set requestCount to 0 (no request completed within the window),
+	// which is what makes the distinction between "data received" and "no data"
+	// the deciding factor for the window verdict.
+	tests := []struct {
+		name            string
+		state           *BandwidthCheckState
+		bytesDownloaded int64
+		errorCount      int64
+		wantWithin      string
+		wantErrorLabel  bool
+		wantSuccess     uint64
+		wantFailed      uint64
+	}{
+		{
+			// Long download spanning multiple windows: data received, no request
+			// completed in the window, a couple errored. Healthy throughput passes.
+			name:            "errors but healthy throughput passes",
+			state:           &BandwidthCheckState{MinBandwidthBps: 1_000_000},
+			bytesDownloaded: 28_000_000,
+			errorCount:      2,
+			wantWithin:      "true",
+			wantErrorLabel:  false,
+			wantSuccess:     1,
+		},
+		{
+			// Genuine stall/outage: requests errored and no data was received.
+			name:           "errors with no data fails",
+			state:          &BandwidthCheckState{MinBandwidthBps: 1_000_000},
+			errorCount:     2,
+			wantWithin:     "false",
+			wantErrorLabel: true,
+			wantFailed:     1,
+		},
+		{
+			// With only a maximum configured, a zero-bandwidth window would pass the
+			// maximum check; the no-data error guard must still fail it.
+			name:           "max-only outage fails",
+			state:          &BandwidthCheckState{MaxBandwidthBps: 100_000_000},
+			errorCount:     3,
+			wantWithin:     "false",
+			wantErrorLabel: true,
+			wantFailed:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := newBandwidthChecker(tt.state)
+			c.windowStartTime = time.Now().Add(-1 * time.Second)
+			c.windowBytesDownloaded = tt.bytesDownloaded
+			c.windowErrorCount = tt.errorCount
+
+			metric := c.emitWindowMetric()
+			require.NotNil(t, metric)
+			assert.Equal(t, tt.wantWithin, metric.Metric["within_threshold"])
+			_, hasError := metric.Metric["error"]
+			assert.Equal(t, tt.wantErrorLabel, hasError)
+			assert.Equal(t, tt.wantSuccess, c.counterWindowSuccess.Load())
+			assert.Equal(t, tt.wantFailed, c.counterWindowFailed.Load())
+		})
+	}
+}
+
+func TestBandwidthCheckAction_AllRequestsFailingFailsCheck(t *testing.T) {
+	// Windows can pass purely on measured throughput while every request fails
+	// (e.g. connections reset mid-body). The run-level guard must still fail the
+	// check because no request completed successfully and requests did error.
+	action := &httpCheckActionBandwidth{}
+	state := action.NewEmptyState()
+	state.ExecutionID = uuid.New()
+	state.SuccessRate = 100
+
+	checker := newBandwidthChecker(&state)
+	checker.counterWindowSuccess.Store(5)
+	checker.counterRequestsErrored.Store(5)
+	bandwidthCheckers.Store(state.ExecutionID, checker)
+
+	stopResult, err := action.Stop(context.Background(), &state)
+	require.NoError(t, err)
+	require.NotNil(t, stopResult)
+	require.NotNil(t, stopResult.Error)
+	assert.Contains(t, stopResult.Error.Title, "No HTTP requests completed successfully")
+}
+
+func TestBandwidthCheckAction_InFlightDownloadDoesNotFalselyFail(t *testing.T) {
+	// A large download that is still in flight at stop has produced healthy
+	// windows but no completed request yet, and crucially no errors. The
+	// run-level guard must not fail such a run.
+	action := &httpCheckActionBandwidth{}
+	state := action.NewEmptyState()
+	state.ExecutionID = uuid.New()
+	state.SuccessRate = 100
+
+	checker := newBandwidthChecker(&state)
+	checker.counterWindowSuccess.Store(5)
+	bandwidthCheckers.Store(state.ExecutionID, checker)
+
+	stopResult, err := action.Stop(context.Background(), &state)
+	require.NoError(t, err)
+	require.NotNil(t, stopResult)
+	assert.Nil(t, stopResult.Error)
+}
+
 func TestBandwidthCheckAction_NonSuccessStatusCode(t *testing.T) {
 	// Server returns 403 Forbidden with a small body (simulates user-agent blocking)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem

A bandwidth check (e.g. experiment GITHUB-220, execution 128100) failed with `Success Rate (85.71%) was below 100% (based on 7 measurement windows)` even though every point on the metrics graph showed healthy throughput.

Inspecting the real execution data, the single failing window had measured **224 Mbps** (28 MB downloaded, 0 completed requests, 2 errored requests) — far above the configured `1mbit` minimum. It was failed solely by this rule:

```go
if errorCount > 0 && requestCount == 0 {
    withinThreshold = false
}
```

With 20 concurrent long-running downloads of a large file, request completions arrive in bursts: a 1-second window can receive megabytes of in-flight data while no request happens to finish within it, and a couple of in-flight requests time out during a transient server stall. The hub documentation defines Required Success Rate as *"Percentage of measurement windows that must be within the bandwidth thresholds"*, so a 224 Mbps window must count as passing — the rule above was undocumented behavior contradicting that contract, and the default 100% gate turned one such window into a whole-run failure.

## Changes

- **Window verdict by throughput.** A window is within threshold when its measured bandwidth is within the configured limits. Errors fail a window only when **no data was received at all** (`bytesDownloaded == 0`) — a genuine stall — which also preserves the safety net for maximum-only configurations where a zero-bandwidth window would otherwise pass.
- **Run-level guard.** The check now fails if **no HTTP request completes successfully** over the entire run, so a target that delivers throughput while failing every request (e.g. resets mid-body) is not reported as healthy.
- **Line chart "Error" group fix.** The widget matched on an `error` label the metric never emitted; that label is now emitted for no-data error windows, and the group is ordered before "Outside Threshold" so it takes precedence (the platform evaluates groups in order — confirmed by the `Fallback` matcher in the API).
- **Parameter description.** The bandwidth action now has its own "Required Success Rate" description (window-based), reusing the shared parameter struct and overriding only the text rather than inheriting the per-request wording.

## Tests

- Table-driven `TestBandwidthChecker_WindowClassification` covering: errors with healthy throughput (passes), errors with no data (fails), and a maximum-only outage (fails).
- `TestBandwidthCheckAction_AllRequestsFailingFailsCheck` covering the run-level guard.
- Existing bandwidth tests still pass (`go test ./exthttpcheck/`).