### PR TITLE
fix: cancel bandwidth requests on stop and reject maxConcurrent of 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: cancel in-flight bandwidth-check requests on stop so workers blocked on a slow or stalled endpoint no longer leak their goroutine and connection
+- fix: reject a `maxConcurrent` of 0 in the HTTP check actions instead of deadlocking the request scheduler
+
 ## v1.0.44
 
 - build(deps): bump github.com/steadybit/extension-kit

--- a/exthttpcheck/bandwidthChecker.go
+++ b/exthttpcheck/bandwidthChecker.go
@@ -4,6 +4,7 @@
 package exthttpcheck
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"io"
@@ -40,15 +41,19 @@ type bandwidthChecker struct {
 	counterRequestsErrored   atomic.Uint64
 
 	// Control
-	stopped atomic.Bool
-	state   *BandwidthCheckState
+	ctx    context.Context
+	cancel context.CancelFunc
+	state  *BandwidthCheckState
 }
 
 var bandwidthCheckers = sync.Map{}
 
 func newBandwidthChecker(state *BandwidthCheckState) *bandwidthChecker {
+	ctx, cancel := context.WithCancel(context.Background())
 	return &bandwidthChecker{
-		state: state,
+		ctx:    ctx,
+		cancel: cancel,
+		state:  state,
 	}
 }
 
@@ -70,7 +75,12 @@ func (c *bandwidthChecker) start() {
 }
 
 func (c *bandwidthChecker) stop() {
-	c.stopped.Store(true)
+	// Cancelling the context stops the worker loop and aborts any in-flight request or
+	// body read, so workers blocked on a slow or stalled endpoint return promptly instead
+	// of leaking their goroutine and connection. Context cancellation propagates through
+	// net/http to a blocked response.Body.Read, which is why no overall client timeout
+	// (which would cap legitimate long downloads) is needed.
+	c.cancel()
 }
 
 func (c *bandwidthChecker) performBandwidthRequests() {
@@ -96,8 +106,8 @@ func (c *bandwidthChecker) performBandwidthRequests() {
 		}
 	}
 
-	for !c.stopped.Load() {
-		req, err := http.NewRequest("GET", c.state.URL.String(), nil)
+	for c.ctx.Err() == nil {
+		req, err := http.NewRequestWithContext(c.ctx, "GET", c.state.URL.String(), nil)
 		if err != nil {
 			log.Error().Err(err).Msg("Failed to create bandwidth request")
 			c.recordError()
@@ -112,6 +122,9 @@ func (c *bandwidthChecker) performBandwidthRequests() {
 		startTime := time.Now()
 		response, err := client.Do(req)
 		if err != nil {
+			if c.ctx.Err() != nil {
+				return // stopped: the request was cancelled, exit without recording a spurious error
+			}
 			log.Error().Err(err).Msg("Failed to execute bandwidth request")
 			c.recordError()
 			continue
@@ -146,6 +159,9 @@ func (c *bandwidthChecker) performBandwidthRequests() {
 		_ = response.Body.Close()
 
 		if readErr != nil {
+			if c.ctx.Err() != nil {
+				return // stopped: the body read was cancelled, exit without recording a spurious error
+			}
 			log.Error().Err(readErr).Msg("Failed to read response body")
 			c.recordError()
 			continue

--- a/exthttpcheck/check.go
+++ b/exthttpcheck/check.go
@@ -70,6 +70,15 @@ func prepare(request action_kit_api.PrepareActionRequestBody, state *HTTPCheckSt
 		return nil, err
 	}
 
+	// A zero worker count would start no workers and deadlock the request scheduler.
+	if state.MaxConcurrent < 1 {
+		return &action_kit_api.PrepareResult{
+			Error: &action_kit_api.ActionKitError{
+				Title: "Concurrent requests must be at least 1",
+			},
+		}, nil
+	}
+
 	urlString, ok := request.Config["url"]
 	if !ok {
 		return nil, fmt.Errorf("URL is missing")


### PR DESCRIPTION
Addresses the extension-http audit MAJOR findings.

## 1. Goroutine/connection leak (bandwidth check)

The bandwidth-check workers loop issuing requests on an HTTP client with **no overall timeout** (deliberate — bandwidth testing must allow arbitrarily long downloads). `stop()` only set a `stopped` flag, which a worker blocked in `client.Do` or `response.Body.Read` against a slow/stalled endpoint never observes — so the goroutine and its connection leak until the request eventually returns on its own. Repeated runs against a slow endpoint accumulate leaked goroutines/sockets.

**Fix:** drive the workers from a `context` that `stop()` cancels. Requests use `http.NewRequestWithContext`, and cancellation **propagates through net/http to a blocked `response.Body.Read`**, so workers return promptly on stop. The context replaces the now-redundant `stopped` flag as the single control signal (matching the sibling `httpChecker`, which is already ctx-driven).

## 2. Deadlock on `maxConcurrent = 0` (HTTP check)

`maxConcurrent` was read with no lower bound. A value of `0` starts **no workers**, leaves an **unbuffered** work channel, and the scheduler's blocking `c.work <- struct{}{}` then hangs the `Start` handler forever.

**Fix:** reject `maxConcurrent < 1` in `prepare` with a clear error (matching the existing guard in the bandwidth action). Placed after header validation to preserve existing validation precedence.

## Testing
- `go build ./...`, `go vet`, `gofmt` clean; `go test ./exthttpcheck/` passes.

## /simplify
4-agent pass. Applied the altitude/simplification consensus: **dropped the redundant `stopped` flag** (context is now the single source of truth, like `httpChecker`), removed the dead `cancel != nil` guard, and added a comment documenting that ctx cancellation reaches `Body.Read` (the non-obvious linchpin). Noted as out-of-scope follow-ups: the bandwidth client builder duplicates `createHttpClient` (pre-existing; spans two state structs), a shared `MaxConcurrent` validator (kept inline to match the existing convention), and a symmetric upper-bound guard (UI already caps at 50).